### PR TITLE
Handle GovNotify failure to send notification

### DIFF
--- a/components/report-repair/confirmation.js
+++ b/components/report-repair/confirmation.js
@@ -3,7 +3,7 @@ import React from 'react';
 import TextLink from '../textLink';
 import { serviceName } from '../../helpers/constants';
 
-const Confirmation = ({ requestId, confirmation }) => {
+const Confirmation = ({ confirmation }) => {
   const title = 'Repair request complete';
   return (
     <div className="govuk-grid-row" data-cy="confirmation">
@@ -13,10 +13,17 @@ const Confirmation = ({ requestId, confirmation }) => {
           <div className="govuk-panel__body">
             Your repair number is
             <br />
-            <strong>{requestId}</strong>
+            <strong>{confirmation.reference}</strong>
           </div>
         </div>
-        <p>We have sent a confirmation to {confirmation}.</p>
+        {confirmation.govNotifyStatus == 'success' ? (
+          <p>We have sent a confirmation to {confirmation.contactDetails}.</p>
+        ) : (
+          <p>
+            We were unable to send a confirmation to{' '}
+            {confirmation.contactDetails}.
+          </p>
+        )}
         <p>
           You will need to provide your repair number and postcode to either
           change or cancel your booking.

--- a/pages/report-repair/[route].js
+++ b/pages/report-repair/[route].js
@@ -63,9 +63,13 @@ function ReportRepair() {
   };
 
   const [showBack, setShowBack] = useState(true);
-  const [confirmation, setConfirmation] = useState('');
+  // Would not have to do this default initialisation if the code was structured like a normal NextJS application
+  const [confirmation, setConfirmation] = useState({
+    govNotifyStatus: '',
+    reference: '',
+    contactDetails: '',
+  });
   const [formError, setFormError] = useState();
-  const [requestId, setRequestId] = useState();
 
   const cleanPayload = (payload) => {
     delete payload.availability.appointmentSlotKey;
@@ -91,9 +95,12 @@ function ReportRepair() {
       if (response.ok) {
         setShowBack(false);
         router.push('confirmation');
-        setConfirmation(values.contactDetails.value);
-        return response.json().then((json) => {
-          setRequestId(json);
+        return response.json().then((response) => {
+          setConfirmation({
+            contactDetails: values.contactDetails.value,
+            reference: response.reference,
+            govNotifyStatus: response.govNotifyStatus,
+          });
         });
       }
       window.history.scrollRestoration = 'manual';
@@ -149,9 +156,7 @@ function ReportRepair() {
           />
         );
       case 'confirmation':
-        return (
-          <Confirmation requestId={requestId} confirmation={confirmation} />
-        );
+        return <Confirmation confirmation={confirmation} />;
       case 'contact-person':
         return <ContactPerson handleChange={handleChange} values={values} />;
       case 'contact-details':

--- a/tests/cypress/integration/reportRepair/confirmation.spec.js
+++ b/tests/cypress/integration/reportRepair/confirmation.spec.js
@@ -92,7 +92,7 @@ describe('confirmation', () => {
   before(() => {
     intercept_availability_search();
     intercept_address_search();
-    intercept_save_repair(repairID);
+    intercept_save_repair(repairID, 'success');
     completeJourney();
   });
 
@@ -125,12 +125,27 @@ describe('confirmation', () => {
     before(() => {
       intercept_availability_search();
       intercept_address_search();
-      intercept_save_repair(repairID);
+      intercept_save_repair(repairID, 'success');
       completeJourney(true);
     });
 
     it('Displays where the confirmation was sent to', () => {
       cy.contains('We have sent a confirmation to ' + phoneNumber);
+    });
+  });
+
+  context('when repair is saved but GovNotify fails', () => {
+    before(() => {
+      intercept_availability_search();
+      intercept_address_search();
+      intercept_save_repair(repairID, 'failure');
+      completeJourney(true);
+    });
+
+    it('Displays a success message but informs the user that sending a notification failed', () => {
+      cy.get('.govuk-panel').contains('Repair request complete');
+      cy.get('.govuk-panel').contains(repairID);
+      cy.contains('We were unable to send a confirmation to ' + phoneNumber);
     });
   });
 });

--- a/tests/cypress/support/helpers.js
+++ b/tests/cypress/support/helpers.js
@@ -32,13 +32,13 @@ function intercept_availability_search(appointments = dummyAppointments) {
   }).as('availability');
 }
 
-function intercept_save_repair(repairId) {
+function intercept_save_repair(repairId, govNotifyStatus) {
   const api_url = 'http://localhost:3000/api';
 
   cy.intercept('POST', `${api_url}/repair`, {
     statusCode: 201,
-    headers: {'Content-Type': 'application/json'},
-    body: `"${repairId}"`,
+    headers: { 'Content-Type': 'application/json' },
+    body: { govNotifyStatus, reference: repairId },
   }).as('saveRepair');
 }
 


### PR DESCRIPTION
We still want the user to know that their repair succeeded even if GovNotify failed to send a notification.